### PR TITLE
[FEAT]: 카카오 로그인 연동 및 회원가입 연동 (학교 인증 제외)

### DIFF
--- a/src/apis/auth/login.api.js
+++ b/src/apis/auth/login.api.js
@@ -1,14 +1,32 @@
 import axios from 'axios';
 import { authApi } from '../axios-instance';
-import { ACCESS_TOKEN_KEY } from '@/constants/api';
+
 export const postLogin = async () => {
   const { data } = await axios.post('dummy');
   return data;
 };
 
-export const getHealth = async (token) =>
-  await authApi.get('/v1/api/auth/health', {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
+export const getUserDetail = async () => {
+  try {
+    const response = await authApi.get('/v1/api/users/details');
+    return { success: true, data: response.data.data }
+  }
+  catch (error) {
+    console.log('Error : ', error);
+    return { success: false, error: error }
+  }
+}
+export const patchSignup = async (signupData) => {
+  try {
+    const response = await authApi.patch('/v1/api/users/details', {
+      ...signupData,
+      nationality: signupData.nationality.toUpperCase(),  // 대문자만 보내야 함 
+      preferredLanguage: signupData.preferredLanguage.toUpperCase() // 대문자만 보내야 함
+    });
+    return { success: true, data: response.data.data }
+  }
+  catch (error) {
+    console.log('Error : ', error);
+    return { success: false, error: error }
+  }
+}

--- a/src/apis/axios-instance.js
+++ b/src/apis/axios-instance.js
@@ -1,12 +1,12 @@
 import axios from 'axios';
-
+import { ACCESS_TOKEN_KEY } from '../constants/api';
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
-// const token = localStorage.getItem('token');
 
 const axiosInstance = (url, params, options) => {
+  const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
   const instance = axios.create({
-    // baseURL: url, 로컬 사용으로 배포시, 사용 예정
-    // headers: { Authorization: `Bearer ${token}` },
+    baseURL: url,
+    headers: { Authorization: `Bearer ${accessToken}` },
     params: params,
     //그 외
     ...options,

--- a/src/components/common/googleLogin.jsx
+++ b/src/components/common/googleLogin.jsx
@@ -38,9 +38,12 @@ export const GoogleLogin = () => {
 
   return (
     <button
-      type="button"
-      onClick={handleGoogleLogin}
-      className="w-4/5 mx-auto mt-6 cursor-pointer"
-    />
+      type="button" className="flex h-[52px] w-full items-center justify-center gap-[16px] rounded-[12px] bg-white px-[12px] text-center align-middle shadow-navbar"
+    >
+      <img src={GoogleLogo} className="h-[20px] w-[20px]" />
+      <span className="text-[16px] leading-[20px] text-black font-roboto">
+        Sign in with Google
+      </span>
+    </button>
   );
 };

--- a/src/components/common/kakaoLogin.jsx
+++ b/src/components/common/kakaoLogin.jsx
@@ -37,13 +37,13 @@ export const KakaoLogin = () => {
     }
 
     // 나중에 앱으로 redirect Uri 구현되면 삭제할 코드들
-    const { accessToken, refreshToken } = parseTokenFromUrl();
+    /*const { accessToken, refreshToken } = parseTokenFromUrl();
     if (accessToken && refreshToken) {
       const appUrl = ` kampus://login?accessToken=${accessToken}&refreshToken=${refreshToken}`;
       if (!window.Capacitor.isNativePlatform()) {
         window.location.href = appUrl;
       }
-    }
+    }*/
   }, []);
 
   const handleKakaoAuthorize = () => {

--- a/src/pages/auth/login.jsx
+++ b/src/pages/auth/login.jsx
@@ -1,50 +1,33 @@
 import Logo from '@/assets/imgs/kampusLogo.svg?react';
 import { KakaoLogin } from '@/components/common/kakaoLogin';
 import { GoogleLogin } from '@/components/common/googleLogin';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { parseTokenFromUrl } from '@/utils/authUtils';
-import { getHealth } from '@/apis/auth/login.api';
-import { SecureStoragePlugin } from 'capacitor-secure-storage-plugin';
-import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from '@/constants/api';
+import { getUserDetail } from '../../apis/auth/login.api';
+import { useNavigate } from 'react-router-dom';
+import { path } from '@/routes/path';
+import { setTokens } from '../../utils/authUtils';
 export const Login = () => {
-  const [data, setData] = useState();
+  const navigate = useNavigate();
   useEffect(() => {
-    /*const tokens = parseTokenFromUrl();
-    if (tokens.accessToken || tokens.refreshToken) {
-      console.log("Access");
-      getHealth(tokens.accessToken)
-        .then(response => {   // 서버 응답 확인용 | 응답 받으면 화면에 200 OK가 뜸 
-          setData({
-            status: response.status,
-            statusText: response.statusText
-          });
-        })
-    }*/
-    const checkTokens = async () => {
-      // SecureStorage에서 토큰 값을 비동기적으로 가져옵니다.
-      const accessToken = await SecureStoragePlugin.get({
-        key: ACCESS_TOKEN_KEY,
-      });
-      const refreshToken = await SecureStoragePlugin.get({
-        key: REFRESH_TOKEN_KEY,
-      });
-
-      // 토큰 값이 null이 아닌 경우에만 작업을 수행합니다.
-      if (accessToken !== null || refreshToken !== null) {
-        // accessToken을 사용하여 API 호출
-        getHealth(accessToken)
-          .then((response) => {
-            alert(response.status);
-            setData({
-              status: response.status,
-            });
-          })
-          .catch((error) => {
-            console.error(error);
-          });
+    const handleLogin = async () => {
+      const { accessToken, refreshToken } = parseTokenFromUrl();
+      if (!accessToken || !refreshToken) {
+        return
       }
-    };
-    checkTokens();
+      await setTokens({ accessToken, refreshToken })
+      const { data, success } = await getUserDetail();
+      if (success && data.needSetup) {
+        navigate(path.signup.base);
+      }
+      else if (success && !data.needSetup) {
+        navigate(path.home);
+      }
+      else {
+        alert("Login Failed!")
+      }
+    }
+    handleLogin();
   }, []);
   return (
     <div className="flex items-center flex-1">
@@ -55,7 +38,6 @@ export const Login = () => {
           <GoogleLogin />
         </div>
       </div>
-      {data && <p className="w-4/5 mx-auto mt-6">{data.status}</p>}
     </div>
   );
 };

--- a/src/pages/auth/profileSettings.jsx
+++ b/src/pages/auth/profileSettings.jsx
@@ -8,6 +8,7 @@ import { SearchDropdown } from '@/components/join/searchDropdown';
 import Nations from '@/constants/nations';
 import Languages from '@/constants/languages';
 import axios from 'axios';
+import { patchSignup } from '../../apis/auth/login.api';
 
 export const ProfileSettings = () => {
   const location = useLocation();
@@ -50,7 +51,19 @@ export const ProfileSettings = () => {
     !isNationalitySelected ||
     !isLanguageSelected;
 
-  const handleClickJoinNow = () => {
+  const returnSignupData = () => {
+    const signupData = {
+      nickname: userName,
+      nationality: nationality,
+      preferredLanguage: language,
+      personalInfoAgreement: true,
+      privacyPolicyAgreement: true,
+      termsOfServiceAgreement: true,
+      marketingAgreement: term
+    }
+    return signupData
+  }
+  const handleClickJoinNow = async () => {
     // api 수정되면 terms, language도 추가로 보내주기
     // axios.post('https://kampus.kro.kr/v1/api/auth/signup', {
     //   "email": "arghstjdy",
@@ -66,7 +79,14 @@ export const ProfileSettings = () => {
     // .catch(error => {
     //   console.log('회원가입 에러: ', error);
     // });
-    navigate(`../${path.signup.welcome}`);
+    const { data, success } = await patchSignup(returnSignupData());
+    if (success) {
+      // 우선은 userId를 쓰는 곳이 없어서 저장안해뒀는데 필요하면 추가시키겠습니다!
+      navigate(`${path.signup.base}/${path.signup.welcome}`);
+    }
+    else {
+      alert("Something wrong. Please try again.")
+    }
   };
 
   return (

--- a/src/utils/authUtils.js
+++ b/src/utils/authUtils.js
@@ -1,8 +1,54 @@
-import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from '@/constants/api';
+import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from "@/constants/api";
+import { Capacitor } from "@capacitor/core";
+import { SecureStoragePlugin } from "capacitor-secure-storage-plugin";
+
 export const parseTokenFromUrl = () => {
-  const urlParams = new URLSearchParams(window.location.search);
-  return {
-    accessToken: urlParams.get(ACCESS_TOKEN_KEY),
-    refreshToken: urlParams.get(REFRESH_TOKEN_KEY),
-  };
+    const urlParams = new URLSearchParams(window.location.search);
+    return {
+        accessToken: urlParams.get(ACCESS_TOKEN_KEY),
+        refreshToken: urlParams.get(REFRESH_TOKEN_KEY),
+    };
+};
+export const getTokens = async () => {
+
+    // 네이티브 환경과 웹 환경 구분 
+    let accessToken, refreshToken
+    if (Capacitor.isNativePlatform()) {
+        accessToken = await SecureStoragePlugin.get({ key: ACCESS_TOKEN_KEY });
+        refreshToken = await SecureStoragePlugin.get({ key: REFRESH_TOKEN_KEY });
+    }
+    else {
+        accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
+        refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY);
+    }
+
+    // 토큰 값이 null인 경우, 로그인 화면으로 redirect
+    if (accessToken === null && refreshToken === null) {
+        return null;
+    }
+    else {
+        return { accessToken, refreshToken };
+    }
+};
+export const setTokens = async ({ accessToken, refreshToken }) => {
+    // 네이티브 환경과 웹 환경 구분
+    if (Capacitor.isNativePlatform()) {
+        await SecureStoragePlugin.set({ key: ACCESS_TOKEN_KEY, value: accessToken });
+        await SecureStoragePlugin.set({ key: REFRESH_TOKEN_KEY, value: refreshToken });
+    }
+    else {
+        accessToken = localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
+        refreshToken = localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
+    }
+}
+export const removeTokens = async () => {
+    if (Capacitor.isNativePlatform()) {
+        // 네이티브 환경 -> SecureStorage 삭제
+        await SecureStoragePlugin.remove({ key: ACCESS_TOKEN_KEY });
+        await SecureStoragePlugin.remove({ key: REFRESH_TOKEN_KEY });
+    } else {
+        // 웹 환경 -> localStorage 삭제
+        localStorage.removeItem(ACCESS_TOKEN_KEY);
+        localStorage.removeItem(REFRESH_TOKEN_KEY);
+    }
 };


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

Resolves: #56 
웹에서 카카오로 로그인 시, 회원가입까지 연동 하였습니다

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정

## 작업 내용
웹에서 카카오 로그인과 회원가입 연동하였습니다 
<!-- 작업 사항에 대한 설명을 적어주세요 -->

## 스크린샷
제가 테스트하면서 이미 저는 회원가입이 되어버려서 동영상을 못찍습니다... 

카카오 로그인 (회원가입 X) -> 회원가입 창 -> 학교인증 창
카카오 로그인 (회원가입 O) -> 홈화면
 
<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->

## 공유사항 to 리뷰어
현재 채팅 구현을 위해 간단하게 연동만 해두었습니다! 
토큰 생명주기나 react Query 이용해서 하는 부분은 추후에 연동 하면서 추가하겠습니다
그리고, 현재 회원가입 할 때, 언어 선택이랑 국가 선택이 백엔드 형식이랑 안맞는 것 같습니다
회원가입할 때, Korea 와 Korean을 선택하니 400 bad request가 떠서 계속 해보다가 대소문자 문제인 것 같아서 
대문자로 다 UpperCase하니 회원가입이 되었습니다
테스트 하실 때 Korea와 Korean으로 회원가입 해주시면 됩니다 :) 
학교 이메일도 연동하려다가 백엔드랑 아직 타입이 정해지지 않은 것 같아서 이것도 회의 이후 추후에 연동하도록 하겠습니다

<!-- 리뷰어가 중점적으로 봐주었으면 좋겠는 부분을 적어주세요 -->
<!-- 논의할 사항이 있다면 적어주세요 -->

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
