### PR TITLE
[FEAT] Username 중복 확인 연동

### DIFF
--- a/src/apis/auth/duplicateCheck.api.js
+++ b/src/apis/auth/duplicateCheck.api.js
@@ -1,0 +1,11 @@
+import { API_DOMAINS } from '@/constants/api';
+import { authApi } from '../axios-instance';
+
+export const duplicateCheck = async ({ data }) => {
+  const response = await authApi.post(API_DOMAINS.DUPLICATE_CHECK, data, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  return response.data.data;
+};

--- a/src/apis/auth/duplicateCheck.api.js
+++ b/src/apis/auth/duplicateCheck.api.js
@@ -1,7 +1,7 @@
 import { API_DOMAINS } from '@/constants/api';
 import { authApi } from '../axios-instance';
 
-export const duplicateCheck = async ({ data }) => {
+export const postDuplicateCheck = async ({ data }) => {
   const response = await authApi.post(API_DOMAINS.DUPLICATE_CHECK, data, {
     headers: {
       'Content-Type': 'application/json',

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -10,6 +10,8 @@ export const API_DOMAINS = {
   USER: '/users/details',
   MYPAGE: '/mypage',
 
+  DUPLICATE_CHECK: '/users/check-nickname',
+
   PRODUCTS: '/products',
 
   CREATE_CHAT: '/chats/post',

--- a/src/hooks/use-Debounce.js
+++ b/src/hooks/use-Debounce.js
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+const useDebounce = (value, delay) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+  
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    }; //value 변경 시점에 clearTimeout
+  }, [value]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;

--- a/src/hooks/use-duplicateCheck.js
+++ b/src/hooks/use-duplicateCheck.js
@@ -1,0 +1,20 @@
+import { useMutation } from '@tanstack/react-query';
+import { toast } from 'react-toastify';
+
+export const useDuplicateCheck = (apiFunction) => {
+
+    const { mutate } = useMutation({
+    // mutationFn: api 함수,
+    mutationFn: apiFunction,
+    onSuccess: () => {
+      toast.success('중복확인 완료');
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  return {
+    mutate,
+  };
+};

--- a/src/pages/auth/profileSettings.jsx
+++ b/src/pages/auth/profileSettings.jsx
@@ -44,7 +44,7 @@ export const ProfileSettings = () => {
     setIsUserNameFormatInvalid(!validateUserNameValue(value));
   };
 
-  const { mutate } = useDuplicateCheck(duplicateCheck);
+  const { mutate } = useDuplicateCheck(postDuplicateCheck);
 
   const handleDuplicateCheck = (value) => {
     mutate({ data: { nickname: value } }, {

--- a/src/pages/auth/profileSettings.jsx
+++ b/src/pages/auth/profileSettings.jsx
@@ -10,7 +10,7 @@ import { patchSignup } from '../../apis/auth/login.api';
 import { TitleHeader } from '@/components/common/titleHeader';
 import useDebounce from '@/hooks/use-Debounce';
 import { useDuplicateCheck } from '@/hooks/use-duplicateCheck';
-import { duplicateCheck } from '@/apis/auth/duplicateCheck.api';
+import { postDuplicateCheck } from '@/apis/auth/duplicateCheck.api';
 
 export const ProfileSettings = () => {
   const location = useLocation();

--- a/src/pages/auth/profileSettings.jsx
+++ b/src/pages/auth/profileSettings.jsx
@@ -1,21 +1,21 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { path } from '@/routes/path';
-import PreviousButton from '@/assets/imgs/previous.svg';
 import { MainButton } from '@/components/common/MainButton';
 import { UserNameInput } from '@/components/join/usernameInput';
 import { SearchDropdown } from '@/components/join/searchDropdown';
 import Nations from '@/constants/nations';
 import Languages from '@/constants/languages';
-import axios from 'axios';
 import { patchSignup } from '../../apis/auth/login.api';
 import { TitleHeader } from '@/components/common/titleHeader';
+import useDebounce from '@/hooks/use-Debounce';
 
 export const ProfileSettings = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const [userName, setUserName] = useState('');
   const [isUserNameFormatInvalid, setIsUserNameFormatInvalid] = useState(false);
+  const [debounceState, setDebunceState] = useState('');
   const [isUserNameDuplicated, setIsUserNameDuplicated] = useState(false);
   const [nationality, setNationality] = useState('');
   const [isNationalitySelected, setIsNationalitySelected] = useState(false);
@@ -36,10 +36,23 @@ export const ProfileSettings = () => {
     return regex.test(value);
   };
 
+  const debouncedUserName = useDebounce(userName, 1000); // 입력을 마치고 500ms 후 중복 체크를 위함
+
   const handleUserNameChange = (value) => {
     setUserName(value);
     setIsUserNameFormatInvalid(!validateUserNameValue(value));
   };
+  
+  const handleDuplicateCheck = (value) => {
+    const isDuplicate = true; // api 연결
+    setIsUserNameDuplicated(isDuplicate);
+  }
+
+  useEffect(() => {
+    if(!isUserNameFormatInvalid && debouncedUserName) {
+      handleDuplicateCheck(debouncedUserName);
+    }
+  }, [debouncedUserName, isUserNameFormatInvalid]);
 
   const disabled =
     !userName ||
@@ -60,22 +73,8 @@ export const ProfileSettings = () => {
     };
     return signupData;
   };
+  
   const handleClickJoinNow = async () => {
-    // api 수정되면 terms, language도 추가로 보내주기
-    // axios.post('https://kampus.kro.kr/v1/api/auth/signup', {
-    //   "email": "arghstjdy",
-    //   "uniqueId": "aweghsjd",
-    //   "providerId": "awegrh",
-    //   "username": "awrgsth",
-    //   "nickname": userName,
-    //   "nationality": nationality
-    // })
-    // .then(response => {
-    //   console.log('회원가입 성공:', response.data);
-    // })
-    // .catch(error => {
-    //   console.log('회원가입 에러: ', error);
-    // });
     const { data, success } = await patchSignup(returnSignupData());
     if (success) {
       // 우선은 userId를 쓰는 곳이 없어서 저장안해뒀는데 필요하면 추가시키겠습니다!

--- a/src/pages/auth/profileSettings.jsx
+++ b/src/pages/auth/profileSettings.jsx
@@ -9,13 +9,14 @@ import Languages from '@/constants/languages';
 import { patchSignup } from '../../apis/auth/login.api';
 import { TitleHeader } from '@/components/common/titleHeader';
 import useDebounce from '@/hooks/use-Debounce';
+import { useDuplicateCheck } from '@/hooks/use-duplicateCheck';
+import { duplicateCheck } from '@/apis/auth/duplicateCheck.api';
 
 export const ProfileSettings = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const [userName, setUserName] = useState('');
   const [isUserNameFormatInvalid, setIsUserNameFormatInvalid] = useState(false);
-  const [debounceState, setDebunceState] = useState('');
   const [isUserNameDuplicated, setIsUserNameDuplicated] = useState(false);
   const [nationality, setNationality] = useState('');
   const [isNationalitySelected, setIsNationalitySelected] = useState(false);
@@ -42,14 +43,19 @@ export const ProfileSettings = () => {
     setUserName(value);
     setIsUserNameFormatInvalid(!validateUserNameValue(value));
   };
-  
+
+  const { mutate } = useDuplicateCheck(duplicateCheck);
+
   const handleDuplicateCheck = (value) => {
-    const isDuplicate = true; // api 연결
-    setIsUserNameDuplicated(isDuplicate);
-  }
+    mutate({ data: { nickname: value } }, {
+      onSuccess: (response) => {
+        setIsUserNameDuplicated(!(response?.isAvailable)); // API 응답에 따라 상태 업데이트
+      },
+    });
+  };
 
   useEffect(() => {
-    if(!isUserNameFormatInvalid && debouncedUserName) {
+    if (!isUserNameFormatInvalid && debouncedUserName) {
       handleDuplicateCheck(debouncedUserName);
     }
   }, [debouncedUserName, isUserNameFormatInvalid]);
@@ -73,7 +79,7 @@ export const ProfileSettings = () => {
     };
     return signupData;
   };
-  
+
   const handleClickJoinNow = async () => {
     const { data, success } = await patchSignup(returnSignupData());
     if (success) {
@@ -86,44 +92,42 @@ export const ProfileSettings = () => {
 
   return (
     <div className="flex flex-col w-full h-full">
-          <TitleHeader
-            text="Profile Settings"
+      <TitleHeader text="Profile Settings" />
+      <div className="flex flex-col px-4 py-[.625rem]">
+        <div className="mb-5 mt-12 flex w-full flex-col space-y-[1.875rem]">
+          <UserNameInput
+            userName={userName}
+            onChange={handleUserNameChange}
+            invalid={isUserNameFormatInvalid}
+            duplicated={isUserNameDuplicated}
           />
-          <div className='flex flex-col px-4 py-[.625rem]'>
-            <div className="mb-5 mt-12 flex w-full flex-col space-y-[1.875rem]">
-        <UserNameInput
-          userName={userName}
-          onChange={handleUserNameChange}
-          invalid={isUserNameFormatInvalid}
-          duplicated={isUserNameDuplicated}
-        />
-        <SearchDropdown
-          keyword={nationality}
-          name="Nationality"
-          placeholder="Select your nationality"
-          onChange={(value) => setNationality(value)}
-          setIsSelected={setIsNationalitySelected}
-          selected={isNationalitySelected}
-          list={Nations}
-          warn="You have to select your country"
-        />
-        <SearchDropdown
-          keyword={language}
-          name="Language"
-          placeholder="Select your language"
-          onChange={(value) => setLanguage(value)}
-          setIsSelected={setIsLanguageSelected}
-          selected={isLanguageSelected}
-          list={Languages}
-          warn="You have to select your language"
-        />
+          <SearchDropdown
+            keyword={nationality}
+            name="Nationality"
+            placeholder="Select your nationality"
+            onChange={(value) => setNationality(value)}
+            setIsSelected={setIsNationalitySelected}
+            selected={isNationalitySelected}
+            list={Nations}
+            warn="You have to select your country"
+          />
+          <SearchDropdown
+            keyword={language}
+            name="Language"
+            placeholder="Select your language"
+            onChange={(value) => setLanguage(value)}
+            setIsSelected={setIsLanguageSelected}
+            selected={isLanguageSelected}
+            list={Languages}
+            warn="You have to select your language"
+          />
+        </div>
+        <div className="flex mt-8 mb-5">
+          <MainButton onClick={handleClickJoinNow} disabled={disabled}>
+            Join Now
+          </MainButton>
+        </div>
       </div>
-      <div className="flex mt-8 mb-5">
-        <MainButton onClick={handleClickJoinNow} disabled={disabled}>
-          Join Now
-        </MainButton>
-      </div>
-    </div>
     </div>
   );
 };

--- a/src/pages/auth/profileSettings.jsx
+++ b/src/pages/auth/profileSettings.jsx
@@ -37,7 +37,7 @@ export const ProfileSettings = () => {
     return regex.test(value);
   };
 
-  const debouncedUserName = useDebounce(userName, 1000); // 입력을 마치고 500ms 후 중복 체크를 위함
+  const debouncedUserName = useDebounce(userName, 300); // 입력을 마치고 300ms 후 중복 체크를 위함
 
   const handleUserNameChange = (value) => {
     setUserName(value);

--- a/src/pages/my/settings/MyInfo.jsx
+++ b/src/pages/my/settings/MyInfo.jsx
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 import { DisabledInput } from '@/components/common/DisabledInput';
 import { MainButton } from '@/components/common/MainButton';
 import { MainWhiteButton } from '@/components/common/MainWhiteButton';
@@ -8,7 +6,10 @@ import { TitleHeader } from '@/components/common/titleHeader';
 import { SearchDropdown } from '@/components/join/searchDropdown';
 import { UserNameInput } from '@/components/join/usernameInput';
 import Languages from '@/constants/languages';
+import useDebounce from '@/hooks/use-Debounce';
+import { useDuplicateCheck } from '@/hooks/use-duplicateCheck';
 import { useEffect, useState } from 'react';
+import { postDuplicateCheck } from '@/apis/auth/duplicateCheck.api';
 import { useNavigate } from 'react-router-dom';
 
 export const MyInfo = () => {
@@ -37,11 +38,6 @@ export const MyInfo = () => {
     return regex.test(value);
   };
 
-  const handleUserNameChange = (value) => {
-    setInfo((prev) => ({ ...prev, username: value }));
-    setIsUserNameFormatInvalid(!validateUserNameValue(value));
-  };
-
   const handleClickSave = () => {
     // 백 연동 후 마이페이지로 이동
     navigate(-1);
@@ -55,6 +51,32 @@ export const MyInfo = () => {
     }
   };
 
+  const debouncedUserName = useDebounce(info.username, 300); // 입력을 마치고 300ms 후 중복 체크를 위함
+
+  const handleUserNameChange = (value) => {
+    setInfo((prev) => ({ ...prev, username: value }));
+    setIsUserNameFormatInvalid(!validateUserNameValue(value));
+  };
+
+  const { mutate } = useDuplicateCheck(postDuplicateCheck);
+
+  const handleDuplicateCheck = (value) => {
+    mutate(
+      { data: { nickname: value } },
+      {
+        onSuccess: (response) => {
+          setIsUserNameDuplicated(!response?.isAvailable); // API 응답에 따라 상태 업데이트
+        },
+      },
+    );
+  };
+
+  useEffect(() => {
+    if (!isUserNameFormatInvalid && debouncedUserName && (info.username !== savedInfo.username)) {
+      handleDuplicateCheck(debouncedUserName);
+    }
+  }, [debouncedUserName, isUserNameFormatInvalid]);
+
   const disabled =
     !info.username ||
     isUserNameFormatInvalid ||
@@ -65,7 +87,7 @@ export const MyInfo = () => {
   useEffect(() => {
     const userData = {
       school: '홍익대학교',
-      username: 'cotato',
+      username: 'seoyeon',
       language: 'French',
       nationality: 'France',
     };

--- a/src/pages/my/settings/MyInfo.jsx
+++ b/src/pages/my/settings/MyInfo.jsx
@@ -87,7 +87,7 @@ export const MyInfo = () => {
   useEffect(() => {
     const userData = {
       school: '홍익대학교',
-      username: 'seoyeon',
+      username: 'cotato',
       language: 'French',
       nationality: 'France',
     };


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Issue Number) -->

Resolves: #107 

회원가입, 내 정보 수정 페이지에서 username duplicate check 연동

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## 작업 내용

<!-- 작업 사항에 대한 설명을 적어주세요 -->

회원가입, 내 정보 수정 페이지에서 username(nickname) 중복 확인 부분 연동했습니다.
debounce 사용해서 사용자가 입력을 멈춘지 300ms 뒤에 중복 확인을 요청합니다.

## 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->

<img width="283" alt="image" src="https://github.com/user-attachments/assets/06cd00c7-d2ef-47f0-bf47-636d1cb8840d" />
<img width="283" alt="image" src="https://github.com/user-attachments/assets/f00ba700-8b01-4fb8-8d7d-107c9acb16e5" />


## 공유사항 to 리뷰어

<!-- 리뷰어가 중점적으로 봐주었으면 좋겠는 부분을 적어주세요 -->
<!-- 논의할 사항이 있다면 적어주세요 -->

tanstack query 처음 써봐서 잘못 썼을수도 있습니다...

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
