### PR TITLE
[FEAT] 카카오 로그인 방식 변경 및 인터셉터 구현 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,8 @@
         "sockjs-client": "^1.6.1",
         "tailwind-merge": "^2.6.0",
         "tailwind-scrollbar-hide": "^2.0.0",
-        "tailwindcss": "^3.4.17"
+        "tailwindcss": "^3.4.17",
+        "zustand": "^5.0.5"
       },
       "devDependencies": {
         "@babel/types": "^7.26.7",
@@ -7620,6 +7621,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.5.tgz",
+      "integrity": "sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "sockjs-client": "^1.6.1",
     "tailwind-merge": "^2.6.0",
     "tailwind-scrollbar-hide": "^2.0.0",
-    "tailwindcss": "^3.4.17"
+    "tailwindcss": "^3.4.17",
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
     "@babel/types": "^7.26.7",

--- a/src/apis/auth/login.api.js
+++ b/src/apis/auth/login.api.js
@@ -18,4 +18,3 @@ export const patchSignup = async (signupData) => {
   });
   return { success: true, data: response.data.data };
 };
-

--- a/src/apis/axios-instance.js
+++ b/src/apis/axios-instance.js
@@ -1,13 +1,11 @@
 import axios from 'axios';
-import { ACCESS_TOKEN_KEY } from '../constants/api';
-import { path } from '@/routes/path';
+import { onError, onRequest, onRequestError } from '@/apis/interceptor';
+
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 const axiosInstance = (url, params, options) => {
-  const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
   const instance = axios.create({
     baseURL: url,
-    headers: { Authorization: `Bearer ${accessToken}` },
     params: params,
     //그 외
     ...options,
@@ -17,95 +15,7 @@ const axiosInstance = (url, params, options) => {
 
 export const authApi = axiosInstance(BASE_URL);
 
-/**
- * CSRF 토큰 fetch 에러 핸들러
- */
-const handleFetchCsrfTokenError = (error) => {
-  console.error('CSRF 토큰 가져오기 실패:', error);
-};
-
-/**
- * CSRF 토큰을 가져와서 저장하는 함수
- */
-const fetchCsrfToken = async () => {
-  try {
-    const response = await userAPI.get(API_DOMAINS.CSRF_TOKEN);
-    csrfToken = response.data.csrfToken;
-  } catch (error) {
-    handleFetchCsrfTokenError(error);
-  }
-};
-
-/**
- * 응답 인터셉터: 응답 헤더에 새 CSRF 토큰이 존재하면 업데이트
- */
-const handleResponseTokenUpdate = (response) => {
-  const newToken = response.headers['X-XSRF-TOKEN'];
-  if (newToken) {
-    csrfToken = newToken;
-    console.log('🔄 새로운 CSRF 토큰 적용:', csrfToken);
-  }
-  return response;
-};
-
-/**
- * 에러 응답 핸들러: 각 HTTP 상태코드에 따라 적절한 조치를 수행
- */
-const handleErrorResponse = async (error) => {
-  const originalRequest = error.config;
-  if (error.response) {
-    const { status } = error.response;
-
-    // 403 Forbidden: CSRF 토큰 만료 → 새 토큰 요청 후 재시도 (한번만)
-    if (status === 403 && originalRequest && !originalRequest._retry) {
-      console.warn('⚠️ CSRF 토큰 만료 → 새 토큰을 가져오는 중...');
-      originalRequest._retry = true;
-
-      try {
-        await fetchCsrfToken();
-        originalRequest.headers['X-XSRF-TOKEN'] = csrfToken;
-        return userAPI(originalRequest);
-      } catch (tokenError) {
-        console.error('❌ CSRF 토큰 갱신 실패:', tokenError);
-        return Promise.reject(tokenError);
-      }
-    }
-
-    // 401 Unauthorized: 세션 만료 → 로그아웃 및 리다이렉션
-    if (status === 401) {
-      console.warn('⚠️ 세션 만료 → 로그아웃 처리 중...');
-      try {
-        await postLogout();
-      } catch (serverLogoutError) {
-        console.error('❌ 서버 로그아웃 실패:', serverLogoutError);
-      } finally {
-        useAuthStore.getState().logout();
-      }
-      window.location.href = path.login;
-      return Promise.reject(error);
-    }
-
-    // 440 Login Timeout: 다른 기기 로그인으로 인한 세션 만료
-    if (status === 440) {
-      console.warn('⚠️ 다른 기기에서 로그인하여 세션이 만료됨.');
-      alert('다른 기기에서 로그인하여 로그아웃되었습니다.');
-      try {
-        await postLogout();
-      } catch (serverLogoutError) {
-        console.error('❌ 서버 로그아웃 실패:', serverLogoutError);
-      } finally {
-        useAuthStore.getState().logout();
-      }
-      window.location.href = path.login;
-      return Promise.reject(error);
-    }
-  }
-
-  return Promise.reject(error);
-};
-
-// 요청 및 응답 인터셉터 적용
-authApi.interceptors.response.use(
-  handleResponseTokenUpdate,
-  handleErrorResponse,
-);
+// 요청 인터셉터
+authApi.interceptors.request.use(onRequest, onRequestError);
+// 응답 인터셉터
+authApi.interceptors.response.use((error) => onError(error, authApi));

--- a/src/apis/axios-instance.js
+++ b/src/apis/axios-instance.js
@@ -18,4 +18,7 @@ export const authApi = axiosInstance(BASE_URL);
 // 요청 인터셉터
 authApi.interceptors.request.use(onRequest, onRequestError);
 // 응답 인터셉터
-authApi.interceptors.response.use((error) => onError(error, authApi));
+authApi.interceptors.response.use(
+  (response) => response,
+  (error) => onError(error, authApi),
+);

--- a/src/apis/axios-instance.js
+++ b/src/apis/axios-instance.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { ACCESS_TOKEN_KEY } from '../constants/api';
+import { path } from '@/routes/path';
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 const axiosInstance = (url, params, options) => {
@@ -15,3 +16,96 @@ const axiosInstance = (url, params, options) => {
 };
 
 export const authApi = axiosInstance(BASE_URL);
+
+/**
+ * CSRF 토큰 fetch 에러 핸들러
+ */
+const handleFetchCsrfTokenError = (error) => {
+  console.error('CSRF 토큰 가져오기 실패:', error);
+};
+
+/**
+ * CSRF 토큰을 가져와서 저장하는 함수
+ */
+const fetchCsrfToken = async () => {
+  try {
+    const response = await userAPI.get(API_DOMAINS.CSRF_TOKEN);
+    csrfToken = response.data.csrfToken;
+  } catch (error) {
+    handleFetchCsrfTokenError(error);
+  }
+};
+
+/**
+ * 응답 인터셉터: 응답 헤더에 새 CSRF 토큰이 존재하면 업데이트
+ */
+const handleResponseTokenUpdate = (response) => {
+  const newToken = response.headers['X-XSRF-TOKEN'];
+  if (newToken) {
+    csrfToken = newToken;
+    console.log('🔄 새로운 CSRF 토큰 적용:', csrfToken);
+  }
+  return response;
+};
+
+/**
+ * 에러 응답 핸들러: 각 HTTP 상태코드에 따라 적절한 조치를 수행
+ */
+const handleErrorResponse = async (error) => {
+  const originalRequest = error.config;
+  if (error.response) {
+    const { status } = error.response;
+
+    // 403 Forbidden: CSRF 토큰 만료 → 새 토큰 요청 후 재시도 (한번만)
+    if (status === 403 && originalRequest && !originalRequest._retry) {
+      console.warn('⚠️ CSRF 토큰 만료 → 새 토큰을 가져오는 중...');
+      originalRequest._retry = true;
+
+      try {
+        await fetchCsrfToken();
+        originalRequest.headers['X-XSRF-TOKEN'] = csrfToken;
+        return userAPI(originalRequest);
+      } catch (tokenError) {
+        console.error('❌ CSRF 토큰 갱신 실패:', tokenError);
+        return Promise.reject(tokenError);
+      }
+    }
+
+    // 401 Unauthorized: 세션 만료 → 로그아웃 및 리다이렉션
+    if (status === 401) {
+      console.warn('⚠️ 세션 만료 → 로그아웃 처리 중...');
+      try {
+        await postLogout();
+      } catch (serverLogoutError) {
+        console.error('❌ 서버 로그아웃 실패:', serverLogoutError);
+      } finally {
+        useAuthStore.getState().logout();
+      }
+      window.location.href = path.login;
+      return Promise.reject(error);
+    }
+
+    // 440 Login Timeout: 다른 기기 로그인으로 인한 세션 만료
+    if (status === 440) {
+      console.warn('⚠️ 다른 기기에서 로그인하여 세션이 만료됨.');
+      alert('다른 기기에서 로그인하여 로그아웃되었습니다.');
+      try {
+        await postLogout();
+      } catch (serverLogoutError) {
+        console.error('❌ 서버 로그아웃 실패:', serverLogoutError);
+      } finally {
+        useAuthStore.getState().logout();
+      }
+      window.location.href = path.login;
+      return Promise.reject(error);
+    }
+  }
+
+  return Promise.reject(error);
+};
+
+// 요청 및 응답 인터셉터 적용
+authApi.interceptors.response.use(
+  handleResponseTokenUpdate,
+  handleErrorResponse,
+);

--- a/src/apis/interceptor.js
+++ b/src/apis/interceptor.js
@@ -1,1 +1,123 @@
-//토큰 재발급
+import { useAuthStore } from '@/stores/useAuthStore';
+import { path } from '@/routes/path';
+import { API_DOMAINS } from '@/constants/api';
+
+// 여러 요청이 동시에 실패 했을 때 용도
+let isRefreshing = false;
+let failedQueue = [];
+
+const MAX_RETRIES = 3; // 최대 재시도 횟수
+
+const processQueue = (error, token = null) => {
+  failedQueue.forEach((prom) => {
+    if (error) {
+      prom.reject(error);
+    } else {
+      prom.resolve(token);
+    }
+  });
+  failedQueue = [];
+};
+
+/**
+ * 요청 인터셉터
+ */
+export const onRequest = (config) => {
+  const { accessToken } = useAuthStore.getState();
+  if (accessToken) {
+    config.headers.Authorization = `Bearer ${accessToken}`;
+  }
+  return config;
+};
+
+/**
+ * 요청 에러 인터셉터
+ */
+export const onRequestError = (error) => {
+  console.error('[Request Error]', error);
+  return Promise.reject(error);
+};
+
+/**
+ * 응답 에러 인터셉터
+ * 401, 403 에러 처리 용도
+ */
+export const onError = async (error, api) => {
+  console.error('[Response Error]', error);
+  const originalRequest = error.config;
+  const { status } = error.response || {};
+
+  const currentRetryCount = originalRequest._retryCount || 0; // 재시도 횟수 확인
+
+  // 401 에러 처리 및 재발급 로직 포함
+  if (status === 401 && currentRetryCount < MAX_RETRIES) {
+    originalRequest._retryCount = currentRetryCount + 1;
+
+    if (isRefreshing) {
+      return new Promise((resolve, reject) => {
+        failedQueue.push({ resolve, reject });
+      })
+        .then((newAccessToken) => {
+          originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+          return api(originalRequest);
+        })
+        .catch((err) => Promise.reject(err));
+    }
+
+    isRefreshing = true;
+
+    try {
+      const response = await api.post(
+        API_DOMAINS.POST_ACCESS_TOKEN,
+        {},
+        {
+          withCredentials: true, // refreshToken 추가
+        },
+      );
+      const newAccessToken = response.data.accessToken;
+
+      useAuthStore.getState().setAccessToken(newAccessToken);
+
+      processQueue(null, newAccessToken);
+      return api(originalRequest);
+    } catch (refreshError) {
+      // 토큰 갱신 자체가 실패하면, 로그아웃 후 로그인 창으로 리다이렉트
+      useAuthStore.getState().clearAccessToken();
+      processQueue(refreshError, null);
+      window.location.href = path.login;
+      return Promise.reject(refreshError);
+    } finally {
+      isRefreshing = false;
+    }
+  }
+
+  // 재시도 횟수 초과한 401 에러 처리
+  if (status === 401 && currentRetryCount >= MAX_RETRIES) {
+    console.error(
+      `[Retry Failed] 재시도 횟수(${MAX_RETRIES})를 초과했습니다. 로그아웃 처리합니다.`,
+    );
+    // 이 친구도 디자인 좋은걸로 바꾸면 좋을 듯...
+    alert('세션이 만료되었습니다.');
+    useAuthStore.getState().clearAccessToken();
+    window.location.href = path.login;
+    return Promise.reject(error);
+  }
+
+  // 403 Forbidden 에러 처리
+  if (status === 403) {
+    console.error(
+      '🚫 403 Forbidden 에러. 접근 권한이 없습니다. 로그아웃 처리합니다.',
+    );
+
+    // 추후에 괜찮은 디자인으로 변경하면 좋을 듯 합니당...
+    alert('요청에 대한 접근 권한이 없습니다. 다시 로그인해 주세요.');
+
+    useAuthStore.getState().clearAccessToken();
+
+    window.location.href = path.login;
+
+    return Promise.reject(error);
+  }
+
+  return Promise.reject(error);
+};

--- a/src/apis/interceptor.js
+++ b/src/apis/interceptor.js
@@ -84,7 +84,7 @@ export const onError = async (error, api) => {
       // 토큰 갱신 자체가 실패하면, 로그아웃 후 로그인 창으로 리다이렉트
       useAuthStore.getState().clearAccessToken();
       processQueue(refreshError, null);
-      window.location.href = path.login;
+      window.location.href = path.login.base;
       return Promise.reject(refreshError);
     } finally {
       isRefreshing = false;
@@ -99,7 +99,7 @@ export const onError = async (error, api) => {
     // 이 친구도 디자인 좋은걸로 바꾸면 좋을 듯...
     alert('세션이 만료되었습니다.');
     useAuthStore.getState().clearAccessToken();
-    window.location.href = path.login;
+    window.location.href = path.login.base;
     return Promise.reject(error);
   }
 
@@ -114,7 +114,7 @@ export const onError = async (error, api) => {
 
     useAuthStore.getState().clearAccessToken();
 
-    window.location.href = path.login;
+    window.location.href = path.login.base;
 
     return Promise.reject(error);
   }

--- a/src/apis/interceptor.js
+++ b/src/apis/interceptor.js
@@ -43,7 +43,6 @@ export const onRequestError = (error) => {
  * 401, 403 에러 처리 용도
  */
 export const onError = async (error, api) => {
-  console.error('[Response Error]', error);
   const originalRequest = error.config;
   const { status } = error.response || {};
 

--- a/src/apis/interceptor.js
+++ b/src/apis/interceptor.js
@@ -83,7 +83,7 @@ export const onError = async (error, api) => {
       // 토큰 갱신 자체가 실패하면, 로그아웃 후 로그인 창으로 리다이렉트
       useAuthStore.getState().clearAccessToken();
       processQueue(refreshError, null);
-      window.location.href = path.login.base;
+      window.location.replace = path.login.base;
       return Promise.reject(refreshError);
     } finally {
       isRefreshing = false;
@@ -98,7 +98,7 @@ export const onError = async (error, api) => {
     // 이 친구도 디자인 좋은걸로 바꾸면 좋을 듯...
     alert('세션이 만료되었습니다.');
     useAuthStore.getState().clearAccessToken();
-    window.location.href = path.login.base;
+    window.location.replace = path.login.base;
     return Promise.reject(error);
   }
 
@@ -113,7 +113,7 @@ export const onError = async (error, api) => {
 
     useAuthStore.getState().clearAccessToken();
 
-    window.location.href = path.login.base;
+    window.location.replace = path.login.base;
 
     return Promise.reject(error);
   }

--- a/src/components/common/kakaoLogin.jsx
+++ b/src/components/common/kakaoLogin.jsx
@@ -8,8 +8,7 @@ import { SecureStoragePlugin } from 'capacitor-secure-storage-plugin';
 export const KakaoLogin = () => {
   const kakaoKey = import.meta.env.VITE_KAKAO_JS_KEY;
   const redirectUri =
-    //import.meta.env.VITE_API_SOCKET_URL
-    'https://020c-221-149-135-127.ngrok-free.app' +
+    import.meta.env.VITE_API_SOCKET_URL +
     import.meta.env.VITE_KAKAO_REDIRECT_URI;
 
   useEffect(() => {

--- a/src/components/common/kakaoLogin.jsx
+++ b/src/components/common/kakaoLogin.jsx
@@ -8,49 +8,22 @@ import { SecureStoragePlugin } from 'capacitor-secure-storage-plugin';
 export const KakaoLogin = () => {
   const kakaoKey = import.meta.env.VITE_KAKAO_JS_KEY;
   const redirectUri =
-    import.meta.env.VITE_API_SOCKET_URL + import.meta.env.VITE_KAKAO_REDIRECT_URI;
-  App.addListener('appUrlOpen', async (event) => {
-    const url = event.url; // 전달받은 URL 예: kampus://login?accessToken=abc123&refreshToken=xyz456
-
-    if (url.startsWith('kampus://login')) {
-      const parsedUrl = new URL(url);
-      const accessToken = parsedUrl.searchParams.get('accessToken');
-      const refreshToken = parsedUrl.searchParams.get('refreshToken');
-      if (accessToken && refreshToken) {
-        alert('카카오 로그인 성공');
-        await SecureStoragePlugin.set({
-          key: 'accessToken',
-          value: accessToken,
-        });
-        await SecureStoragePlugin.set({
-          key: 'refreshToken',
-          value: refreshToken,
-        });
-      }
-    }
-  });
+    //import.meta.env.VITE_API_SOCKET_URL
+    'https://020c-221-149-135-127.ngrok-free.app' +
+    import.meta.env.VITE_KAKAO_REDIRECT_URI;
 
   useEffect(() => {
     // Kakao SDK 초기화
     if (!window.Kakao.isInitialized()) {
       window.Kakao.init(kakaoKey); // 카카오 JS 키
     }
-
-    // 나중에 앱으로 redirect Uri 구현되면 삭제할 코드들
-    /*const { accessToken, refreshToken } = parseTokenFromUrl();
-    if (accessToken && refreshToken) {
-      const appUrl = ` kampus://login?accessToken=${accessToken}&refreshToken=${refreshToken}`;
-      if (!window.Capacitor.isNativePlatform()) {
-        window.location.href = appUrl;
-      }
-    }*/
   }, []);
 
   const handleKakaoAuthorize = () => {
     window.Kakao.Auth.authorize({
       redirectUri,
       scope: 'account_email',
-      throughTalk: false  // 카카오 앱이 아닌 브라우저 로그인하게 하는 옵션 
+      throughTalk: false, // 카카오 앱이 아닌 브라우저 로그인하게 하는 옵션
     });
   };
   return (
@@ -60,7 +33,7 @@ export const KakaoLogin = () => {
       className="flex h-[52px] w-full items-center justify-center gap-[16px] rounded-[12px] bg-[#FEE500] px-[12px] text-center align-middle shadow-navbar"
     >
       <img src={KakaoLogo} className="h-[20px] w-[20px]" />
-      <span className="text-[16px] leading-[20px] text-[#191919] font-roboto">
+      <span className="font-roboto text-[16px] leading-[20px] text-[#191919]">
         Start with Kakao
       </span>
     </button>

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -22,7 +22,7 @@ export const API_DOMAINS = {
   VERIFY_SCHOOL_PHOTO: '/users/verify/document',
   SEND_SCHOOL_EMAIL_CODE: '/users/verify/email/send',
   VERIFY_SCHOOL_EMAIL_CODE: '/users/verify/mail/confirm',
-  GET_SCHOOL_STATUS: 'users/verify/status',
+  GET_SCHOOL_STATUS: '/cert/status',
 
   PRODUCTS: '/products',
 

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -10,6 +10,7 @@ export const API_DOMAINS = {
   USER: '/users/details',
   PATCH_USER: '/users/info',
   MYPAGE: '/mypage',
+  POST_ACCESS_TOKEN: '/auth/reissue',
 
   GET_MY_POSTS: '/posts/my',
   GET_MY_COMMENTED_POST: '/my/commented-post',

--- a/src/pages/SplashScreen.jsx
+++ b/src/pages/SplashScreen.jsx
@@ -9,14 +9,14 @@ export const SplashScreen = () => {
   useEffect(() => {
     const timer = setTimeout(() => {
       //로그인 상태일경우 path.board로 이동
-      navigate(path.login);
+      navigate(path.login.base);
     }, 2000);
 
     return () => clearTimeout(timer);
   }, []);
 
   return (
-    <div className="flex items-center justify-center flex-1 bg-primary-base">
+    <div className="flex flex-1 items-center justify-center bg-primary-base">
       <Logo className="w-[12.5rem] text-white" />
     </div>
   );

--- a/src/pages/auth/handler/KakaoLoginHandler.jsx
+++ b/src/pages/auth/handler/KakaoLoginHandler.jsx
@@ -3,29 +3,46 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { Loading } from '@/components/common/Loading';
 import { path } from '@/routes/path';
+import { getUserDetail } from '@/apis/auth/login.api';
 
 export const KakaoLoginHandler = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const { setAccessToken } = useAuthStore();
 
-  /*useEffect(() => {
+  useEffect(() => {
+    // URL에 토큰 정보가 남지 않도록 replace: true 추가
+    const handleLogin = async () => {
+      const { data, success } = await getUserDetail();
+      if (data === undefined) {
+        alert('Login Failed!');
+        navigate(path.login.base, { replace: true });
+        return;
+      }
+      if (success && data.needSetup) {
+        navigate(path.signup.base, { replace: true });
+      } else if (success && !data.needSetup) {
+        navigate(path.home, { replace: true });
+      } else {
+        alert('Login Failed!');
+        navigate(path.login.base, { replace: true });
+      }
+    };
+
     // URL의 쿼리 문자열에서 accessToken을 파싱
     const searchParams = new URLSearchParams(location.search);
     const accessToken = searchParams.get('accessToken');
 
     if (accessToken) {
       setAccessToken(accessToken);
-
-      // URL에 토큰 정보가 남지 않도록 replace: true 추가
-      navigate(path.home, { replace: true });
+      handleLogin();
     } else {
       // 토큰이 없는 경우, alert 창 이후 로그인 창으로 리다이렉트
       console.error('카카오 로그인 처리 중 에러: Access Token이 없습니다.');
-      alert('카카오 로그인에 실패했습니다. 다시 시도해 주세요.');
+      alert('Kakao Login Failed!');
       navigate(path.login.base, { replace: true });
     }
-  }, [location, navigate, setAccessToken]);*/
+  }, [location]);
 
   return (
     <div className="flex h-screen w-screen items-center justify-center">

--- a/src/pages/auth/handler/KakaoLoginHandler.jsx
+++ b/src/pages/auth/handler/KakaoLoginHandler.jsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useAuthStore } from '@/stores/useAuthStore';
+import { Loading } from '@/components/common/Loading';
+import { path } from '@/routes/path';
+
+export const KakaoLoginHandler = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { setAccessToken } = useAuthStore();
+
+  /*useEffect(() => {
+    // URL의 쿼리 문자열에서 accessToken을 파싱
+    const searchParams = new URLSearchParams(location.search);
+    const accessToken = searchParams.get('accessToken');
+
+    if (accessToken) {
+      setAccessToken(accessToken);
+
+      // URL에 토큰 정보가 남지 않도록 replace: true 추가
+      navigate(path.home, { replace: true });
+    } else {
+      // 토큰이 없는 경우, alert 창 이후 로그인 창으로 리다이렉트
+      console.error('카카오 로그인 처리 중 에러: Access Token이 없습니다.');
+      alert('카카오 로그인에 실패했습니다. 다시 시도해 주세요.');
+      navigate(path.login.base, { replace: true });
+    }
+  }, [location, navigate, setAccessToken]);*/
+
+  return (
+    <div className="flex h-screen w-screen items-center justify-center">
+      <Loading />
+    </div>
+  );
+};

--- a/src/pages/auth/login.jsx
+++ b/src/pages/auth/login.jsx
@@ -1,38 +1,13 @@
 import Logo from '@/assets/imgs/kampusLogo.svg?react';
 import { KakaoLogin } from '@/components/common/kakaoLogin';
 import { GoogleLogin } from '@/components/common/googleLogin';
-import { useEffect } from 'react';
-import { parseTokenFromUrl } from '@/utils/authUtils';
-import { getUserDetail } from '../../apis/auth/login.api';
 import { useNavigate } from 'react-router-dom';
 import { path } from '@/routes/path';
-import { setTokens } from '../../utils/authUtils';
 import { Bubble } from '@/components/common/Bubble';
 
 export const Login = () => {
   const navigate = useNavigate();
 
-  /*useEffect(() => {
-    const handleLogin = async () => {
-      const { accessToken, refreshToken } = parseTokenFromUrl();
-      if (!accessToken || !refreshToken) {
-        return;
-      }
-      await setTokens({ accessToken, refreshToken });
-      const { data, success } = await getUserDetail();
-      if (data === undefined) {
-        window.location.reload();
-      }
-      if (success && data.needSetup) {
-        navigate(path.signup.base);
-      } else if (success && !data.needSetup) {
-        navigate(path.home);
-      } else {
-        alert('Login Failed!');
-      }
-    };
-    handleLogin();
-  }, []);*/
   return (
     <div className="relative flex flex-1 items-center">
       <button

--- a/src/pages/auth/login.jsx
+++ b/src/pages/auth/login.jsx
@@ -12,7 +12,7 @@ import { Bubble } from '@/components/common/Bubble';
 export const Login = () => {
   const navigate = useNavigate();
 
-  useEffect(() => {
+  /*useEffect(() => {
     const handleLogin = async () => {
       const { accessToken, refreshToken } = parseTokenFromUrl();
       if (!accessToken || !refreshToken) {
@@ -32,20 +32,20 @@ export const Login = () => {
       }
     };
     handleLogin();
-  }, []);
+  }, []);*/
   return (
-    <div className="relative flex items-center flex-1">
+    <div className="relative flex flex-1 items-center">
       <button
         onClick={() =>
           navigate(`${path.mypage.base}/${path.mypage.service.base}`)
         }
-        className="absolute px-4 py-2 text-base right-4 top-4 text-neutral-base"
+        className="absolute right-4 top-4 px-4 py-2 text-base text-neutral-base"
       >
         Contact us
       </button>
-      <div className="flex flex-col items-center justify-center w-full gap-6 px-8 -translate-y-12">
+      <div className="flex w-full -translate-y-12 flex-col items-center justify-center gap-6 px-8">
         <Logo className="w-40 text-primary-base" />
-        <div className="flex flex-col w-full gap-4">
+        <div className="flex w-full flex-col gap-4">
           <Bubble
             type="kakao"
             dir="bottom"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,6 +4,7 @@ export { Home } from './home/home';
 export { SplashScreen } from './SplashScreen';
 
 export { Login } from './auth/login';
+export { KakaoLoginHandler } from './auth/handler/KakaoLoginHandler';
 export { Terms } from './auth/terms';
 export { ProfileSettings } from './auth/profileSettings';
 export { Welcome } from './auth/welcome';

--- a/src/pages/my/mypage.jsx
+++ b/src/pages/my/mypage.jsx
@@ -38,7 +38,7 @@ export const MyPage = () => {
 
   const handleLogout = async () => {
     await removeTokens();
-    navigate(path.login);
+    navigate(path.login.base);
   };
 
   return (

--- a/src/pages/my/mypage.jsx
+++ b/src/pages/my/mypage.jsx
@@ -1,5 +1,5 @@
 import arrow from '@/assets/imgs/arrowRight.svg';
-import { useNavigate } from 'react-router-dom';
+import { replace, useNavigate } from 'react-router-dom';
 import { path } from '@/routes/path';
 import { removeTokens } from '@/utils/authUtils';
 import { useEffect, useState } from 'react';
@@ -38,7 +38,7 @@ export const MyPage = () => {
 
   const handleLogout = async () => {
     await removeTokens();
-    navigate(path.login.base);
+    navigate(path.login.base, { replace: true });
   };
 
   return (

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -58,6 +58,7 @@ import {
   AccountPermanentSuspendedNotice,
   MarketWrite,
   ManageCategory,
+  KakaoLoginHandler,
 } from '@/pages';
 import { ContactUs } from '@/components/layout/ContactUs';
 import { BlockingManagement } from '@/components/layout/BlockingManagement';
@@ -81,7 +82,7 @@ const AppRouter = createBrowserRouter([
     ),
   },
   {
-    path: path.login,
+    path: path.login.base,
     element: (
       <Layout>
         <Outlet />
@@ -89,8 +90,12 @@ const AppRouter = createBrowserRouter([
     ),
     children: [
       {
-        path: path.login,
+        path: '',
         element: <Login />,
+      },
+      {
+        path: path.login.kakao,
+        element: <KakaoLoginHandler />,
       },
     ],
   },

--- a/src/routes/path.ts
+++ b/src/routes/path.ts
@@ -1,6 +1,9 @@
 export const path = {
   accountPermanentSuspended: '/account-permanent-suspended',
-  login: '/login',
+  login: {
+    base: '/login',
+    kakao: 'kakao',
+  },
   signup: {
     base: '/signup',
     terms: 'terms',

--- a/src/stores/useAuthStore.js
+++ b/src/stores/useAuthStore.js
@@ -1,0 +1,8 @@
+import { create } from 'zustand';
+
+export const useAuthStore = create((set) => ({
+  accessToken: null,
+
+  setAccessToken: (token) => set({ accessToken: token }),
+  clearAccessToken: () => set({ accessToken: null }),
+}));


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

Resolves: #181 
 카카오 로그인 방식 변경 및 인터셉터 구현 
 
## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정

## 작업 내용

<!-- 작업 사항에 대한 설명을 적어주세요 -->
카카오 로그인 시, 카카오 로그인 핸들러 페이지로 이동하여 
url에서 `accessToken`을 파싱하고 서버 응답값으로 `refreshToken`을 쿠키로 저장하게끔 카카오 로그인 로직을 수정하였습니다.

기존 : 
`accessToken` 및 `refreshToken`을 로컬 스토리지로 관리하던걸 아래와 같이 변경하였습니다.
변경 : 
`accessToken`은 zustand로 관리
`refreshToken`은 쿠키로 관리

추가적으로 인터셉터에서 아래 기능을 구현하였습니다.
- accessToken 만료시, refreshToken을 통한 재발급 로직을 구현
- 401 과 403 오류 핸들러 구현 ( refreshToken 만료 및 권한 없으면 로그인 화면으로 리다이렉트) 

## 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->

## 공유사항 to 리뷰어

- zustand 패키지 설치로 인해 패키지 설치해주셔야 합니다 
- 로컬 스토리지에서 accessToken을 얻어오는 로직이 있다면 이제 zustand에서 얻어오는 로직으로 수정하셔야 합니다
- 인터셉터에 추가적으로 들어가면 좋은 기능 있으시면 말씀해주세요 
<!-- 리뷰어가 중점적으로 봐주었으면 좋겠는 부분을 적어주세요 -->
<!-- 논의할 사항이 있다면 적어주세요 -->

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
