### PR TITLE
[FIX] 새로고침 시 리다이렉트 에러 해결

### DIFF
--- a/src/apis/interceptor.js
+++ b/src/apis/interceptor.js
@@ -111,15 +111,9 @@ export const onError = async (error, api) => {
 
   // 403 Forbidden 에러 처리
   if (status === 403) {
-    console.error(
-      '🚫 403 Forbidden 에러. 접근 권한이 없습니다. 로그아웃 처리합니다.',
-    );
-    alert('요청에 대한 접근 권한이 없습니다. 다시 로그인해 주세요.');
-
-    clearAccessToken();
+    console.error('🚫 403 Forbidden 에러. 접근 권한이 없습니다.');
+    alert('요청에 대한 접근 권한이 없습니다.');
     setInitializing(false);
-
-    window.location.replace(PATH.LOGIN.BASE);
 
     return Promise.reject(error);
   }

--- a/src/routes/PrivateRoute.jsx
+++ b/src/routes/PrivateRoute.jsx
@@ -1,10 +1,9 @@
-import { PATH } from '@/routes/path';
 import { useAuthStore } from '@/stores/useAuthStore';
-import { Navigate, Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 import { Loading } from '@/components/common/Loading';
 
 export default function PrivateRoute() {
-  const { accessToken, isInitializing } = useAuthStore();
+  const { isInitializing } = useAuthStore();
 
   // 토큰 갱신 중일 때는 로딩 화면 표시
   if (isInitializing) {
@@ -17,9 +16,9 @@ export default function PrivateRoute() {
   }
 
   // 토큰 갱신이 완료된 후 토큰이 없으면 로그인 페이지로 리다이렉트
-  if (!isInitializing && !accessToken) {
-    return <Navigate to={PATH.LOGIN.BASE} replace />;
-  }
+  // if (!isInitializing && !accessToken) {
+  //   return <Navigate to={PATH.LOGIN.BASE} replace />;
+  // }
 
   return <Outlet />;
 }


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Issue Number) -->

Resolves: #219 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 버그 수정

## 작업 내용

<!-- 작업 사항에 대한 설명을 적어주세요 -->

- Private Route accessToken 없으면 로그인 페이지로 리다이렉트 시키는 부분 주석 처리
- 403 로그인 페이지로 리다이렉트 시키는 부분 제거

## 공유사항 to 리뷰어

<!-- 리뷰어가 중점적으로 봐주었으면 좋겠는 부분을 적어주세요 -->
<!-- 논의할 사항이 있다면 적어주세요 -->

```js
if (!isInitializing && !accessToken) {
   return <Navigate to={PATH.LOGIN.BASE} replace />;
}
```
reissue를 호출하기도 전에 accessToken을 확인해서 로그인 페이지로 이동하게 됩니다.
궁금해서 네이버랑 네이버 카페에서 새로고침 해봤는데 각각 아래 방식으로 로그인 여부를 확인하고 있는 것 같습니다.

네이버
<img width="495" height="274" alt="image" src="https://github.com/user-attachments/assets/0f01504b-8563-4df8-be0d-846500b950d8" />

네이버 카페
<img width="495" height="274" alt="image" src="https://github.com/user-attachments/assets/be3c361e-0b40-4fea-96bf-d068fae56b8c" />

임시로 주석 처리해놨지만 아래 방법으로 코드를 개선할 수 있을 것 같습니다. @chae-dahee 
Private Route에서 토큰이 필요한 API를 호출하도록 하면, 새로고침하거나 새로운 페이지로 이동할 때 해당 API가 실행됩니다. 이때 accessToken이 없으면 자동으로 reissue가 이루어지게 됩니다.

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
