### PR TITLE
[FIX] 관리자 페이지 리다이렉트 오류 해결

### DIFF
--- a/src/apis/interceptor.js
+++ b/src/apis/interceptor.js
@@ -45,8 +45,7 @@ export const onRequestError = (error) => {
 export const onError = async (error, api) => {
   const originalRequest = error.config;
   const { status } = error.response || {};
-  const { setInitializing, clearAccessToken, setAccessToken } =
-    useAuthStore.getState();
+  const { clearAccessToken, setAccessToken } = useAuthStore.getState();
 
   const currentRetryCount = originalRequest._retryCount || 0; // 재시도 횟수 확인
 
@@ -66,7 +65,7 @@ export const onError = async (error, api) => {
     }
 
     isRefreshing = true;
-    setInitializing(true);
+    useAuthStore.getState().setInitializing(true);
 
     try {
       const response = await api.post(
@@ -93,7 +92,7 @@ export const onError = async (error, api) => {
       return Promise.reject(refreshError);
     } finally {
       isRefreshing = false;
-      setInitializing(false);
+      useAuthStore.getState().setInitializing(false);
     }
   }
 
@@ -104,7 +103,7 @@ export const onError = async (error, api) => {
     );
     alert('세션이 만료되었습니다.');
     clearAccessToken();
-    setInitializing(false);
+    useAuthStore.getState().setInitializing(false);
     window.location.replace(PATH.LOGIN.BASE);
     return Promise.reject(error);
   }
@@ -113,7 +112,7 @@ export const onError = async (error, api) => {
   if (status === 403) {
     console.error('🚫 403 Forbidden 에러. 접근 권한이 없습니다.');
     alert('요청에 대한 접근 권한이 없습니다.');
-    setInitializing(false);
+    useAuthStore.getState().setInitializing(false);
 
     return Promise.reject(error);
   }

--- a/src/apis/user/adminUserDetail.api.js
+++ b/src/apis/user/adminUserDetail.api.js
@@ -2,6 +2,13 @@ import { authApi } from '@/apis/axios-instance';
 import { API_DOMAINS } from '@/constants/api';
 
 export const getAdminUser = async () => {
-  const response = await authApi.get(API_DOMAINS.ADMIN_USER);
-  return response.data.data;
+  try {
+    const response = await authApi.get(API_DOMAINS.ADMIN_USER);
+    return response.data.data;
+  } catch (err) {
+    if (err.response?.status === 403) {
+      throw new Error('FORBIDDEN');
+    }
+    throw err;
+  }
 };

--- a/src/routes/AdminRoute.jsx
+++ b/src/routes/AdminRoute.jsx
@@ -1,45 +1,21 @@
-import { PATH } from '@/routes/path';
-import { useAuthStore } from '@/stores/useAuthStore';
-import { Navigate, Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 import { useGetAdminUserData } from '@/state/query/admin/useGetAdminUserData';
 import { Forbidden } from '@/pages/Forbidden';
 import { Loading } from '@/components/common/Loading';
 import { AdminLayout } from '@/pages';
 
 export default function AdminRoute() {
-  const { accessToken, isInitializing } = useAuthStore();
-
   // 관리자 사용자 정보를 가져와서 권한 확인
-  const { data: userData, isLoading, error } = useGetAdminUserData();
-
-  // 토큰 갱신 중일 때는 로딩 화면 표시
-  if (isInitializing) {
-    return (
-      <div className="flex h-screen w-screen items-center justify-center">
-        <Loading />
-        <p className="text-sm mt-2 text-gray-600">인증 확인 중...</p>
-      </div>
-    );
-  }
-
-  // 토큰 갱신이 완료된 후 토큰이 없으면 로그인 페이지로 리다이렉트
-  if (!isInitializing && !accessToken) {
-    return <Navigate to={PATH.LOGIN.BASE} replace />;
-  }
+  const { data: userData, isLoading } = useGetAdminUserData();
 
   // 로딩 중일 때
   if (isLoading) {
     return (
-      <div className="flex h-screen w-screen items-center justify-center">
+      <div className="flex h-screen w-screen flex-col items-center justify-center gap-2">
         <Loading />
-        <p className="text-sm mt-2 text-gray-600">권한 확인 중...</p>
+        <p className="text-sm text-gray-600">권한 확인 중...</p>
       </div>
     );
-  }
-
-  // 에러가 발생한 경우 (관리자 권한이 없는 경우)
-  if (error) {
-    return <Forbidden />;
   }
 
   // 관리자 권한이 확인된 경우

--- a/src/routes/AdminRoute.jsx
+++ b/src/routes/AdminRoute.jsx
@@ -6,7 +6,7 @@ import { AdminLayout } from '@/pages';
 
 export default function AdminRoute() {
   // 관리자 사용자 정보를 가져와서 권한 확인
-  const { data: userData, isLoading } = useGetAdminUserData();
+  const { data: userData, isLoading, isError, error } = useGetAdminUserData();
 
   // 로딩 중일 때
   if (isLoading) {
@@ -18,6 +18,10 @@ export default function AdminRoute() {
     );
   }
 
+  if (isError && error instanceof Error && error.message === 'FORBIDDEN') {
+    return <Forbidden />;
+  }
+
   // 관리자 권한이 확인된 경우
   if (userData) {
     return (
@@ -27,6 +31,5 @@ export default function AdminRoute() {
     );
   }
 
-  // 기본적으로 권한이 없는 경우
-  return <Forbidden />;
+  return null;
 }

--- a/src/state/query/admin/useGetAdminUserData.js
+++ b/src/state/query/admin/useGetAdminUserData.js
@@ -6,8 +6,8 @@ export const useGetAdminUserData = () => {
   const query = useQuery({
     queryKey: [QUERY_KEYS.GET_ADMIN_USER_ME],
     queryFn: () => getAdminUser(),
-    staleTime: 5 * 60 * 1000, // 5분
-    gcTime: 10 * 60 * 1000, // 10분
+    retry: false,
+    throwOnError: false,
   });
   return query;
 };


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

관리자 페이지 리다이렉트 오류가 있어 Admin Route를 수정했습니다.

<!---- Resolves: #(Issue Number) -->

Resolves: #219 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 버그 수정

## 작업 내용

<!-- 작업 사항에 대한 설명을 적어주세요 -->

- admin route 수정
admin route에서 accessToken이 없으면 일단 로그인 페이지로 리다이렉트 되는 바람에 관리자 페이지 접근이 불가했습니다.
accessToken을 확인하고 리다이렉트 시키는 로직을 삭제했습니다. 관리자 정보 받아오는 api 호출할 때 자동으로 reissue까지 될 예정입니다.
인터셉터에서 React 상태를 직접 제어하려다보니 아래와 같은 에러가 발생하여 수정했습니다.
TypeError: setInitializing is not a function


- 관리자페이지 403 에러 처리
403 에러가 따로 처리가 안되어있어서 Admin Route가 Forbidden을 보여주는 대신 UnknowErrorBoundary가 해당 에러를 캐치하고 있었습니다. 403 에러를 던져서 Forbidden 페이지를 보여주도록 수정했습니다.

## 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->

관리자 권한이 없는 사용자가 접근할 경우
<img width="355" height="766" alt="image" src="https://github.com/user-attachments/assets/4c291078-429a-4867-a4f7-a9d044ec9ccc" />


## 공유사항 to 리뷰어

<!-- 리뷰어가 중점적으로 봐주었으면 좋겠는 부분을 적어주세요 -->
<!-- 논의할 사항이 있다면 적어주세요 -->

Private Route의 isInitializing이 의미가 없을 것 같은데 해당 부분이 꼭 필요한지 확인 부탁드립니다. 필요 없다면 setInitializing과 isInitializing을 지워도 될 것 같습니다.

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
